### PR TITLE
添加 jitpack.yml

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,4 @@
+# jitpack.yml
+
+dependencies:
+    - alias: ef-core


### PR DESCRIPTION
- 通过定义 jitpack 别名，解决项目依赖时 EF-Core 库命名不符合规范问题。